### PR TITLE
Fix build, pass trikRuntime includes path in trik-ros recipe

### DIFF
--- a/recipes-trik/trik-ros/trik-ros_git.bb
+++ b/recipes-trik/trik-ros/trik-ros_git.bb
@@ -11,7 +11,7 @@ SRCREV = "${AUTOREV}"
 PV .= "${SRCPV}"
 S = "${WORKDIR}/git"
 
-EXTRA_OECMAKE_prepend = "-DQT=${STAGING_INCDIR}/qtopia"
+EXTRA_OECMAKE_prepend = "-DQT=${STAGING_INCDIR}/qtopia -DTRIK=${STAGING_INCDIR}/trikRuntime"
 OECMAKE_CXX_FLAGS_prepend = "-std=c++11"
 inherit catkin
 


### PR DESCRIPTION
Add include path in recipe. Need to modify CMakeLists.txt for ros package to avoid this.