### PR TITLE
Fix meta-ros build

### DIFF
--- a/recipes-core/images/trik-base-v2.bb
+++ b/recipes-core/images/trik-base-v2.bb
@@ -9,24 +9,27 @@ IMAGE_INSTALL = "packagegroup-base \
 		packagegroup-qte-trik \
 		packagegroup-core-ssh-dropbear \
 		localedef \
-        procps \
+		procps \
 		packagegroup-firmware \
 		packagegroup-utils \
 		packagegroup-multimedia \
 		packagegroup-core-tools-debug \
-        packagegroup-core-tools-profile\
+	        packagegroup-core-tools-profile \
 		udev-extraconf \
 		mspbsl \
 		rc-local\
 		trik-runtime \
 		trik-examples \
 		dsp-modules \
-    	softap-udhcpd-config \
+		softap-udhcpd-config \
 		trik-network \
 		fuse \
 		eglibc-utils \
 		packagegroup-triksensors \
 		distro-feed-configs \
+		packagegroup-ros-comm \
+		roslaunch \
+		trik-ros \
 		formfactor \
 		live555 \
 		libav \

--- a/recipes-ros/pluginlib/pluginlib_1.10.2.bbappend
+++ b/recipes-ros/pluginlib/pluginlib_1.10.2.bbappend
@@ -1,0 +1,1 @@
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"


### PR DESCRIPTION
Add temporary bbappend to fix build fail due to changed checksum in pluginlib package.
More info on [issue page](https://github.com/bmwcarit/meta-ros/issues/401), waiting for the [PR](https://github.com/bmwcarit/meta-ros/pull/402) to be merged.