### PR TITLE
pixel clock inversion hack for "new" video modules part 2 (the sensor control script)

### DIFF
--- a/recipes-dsp/sensors/files/init-ov7670-320x240.sh
+++ b/recipes-dsp/sensors/files/init-ov7670-320x240.sh
@@ -8,9 +8,6 @@ case ${MCU_VERSION} in
      *) echo ERROR in version detection; exit 1 ;;
 esac
 
-#IS_OLD_CONTROLLER=1
-#if [ `cat /sys/class/graphics/fb0/id` == 00858552 ]; then IS_OLD_CONTROLLER=''; fi
-
 VIDEO0=/dev/video0
 VIDEO1=/dev/video1
 

--- a/recipes-dsp/sensors/files/init-ov7670-320x240.sh
+++ b/recipes-dsp/sensors/files/init-ov7670-320x240.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+IS_OLD_CONTROLLER=1
+if [ `cat /sys/class/graphics/fb0/id` == 00858552 ]; then IS_OLD_CONTROLLER=''; fi
+
 VIDEO0=/dev/video0
 VIDEO1=/dev/video1
 
@@ -39,6 +43,14 @@ cam 0x04 0x40
 
 # Output range: [01] to [FE]
 cam 0x40 0x80
+
+if [ -z "$IS_OLD_CONTROLLER" ]; then 
+  cam 0x15 0x10 
+  v4l2-ctl -d $VIDEO_PATH -c invert_pixel_clock=1
+else
+  cam 0x15 0x00 
+  v4l2-ctl -d $VIDEO_PATH -c invert_pixel_clock=0
+fi 
 
 # set QVGA according to
 # Table 2-2. (but without input clock divider
@@ -121,4 +133,5 @@ cam 0x54 0x40
 #cam 0x20 0x0f //darker sharper
 
 v4l2-ctl -d $VIDEO_PATH -s pal 1 > /dev/null
-echo "ov7670 successfully initialised"
+echo "ov7670 successfully initialised" 
+echo 

--- a/recipes-dsp/sensors/files/init-ov7670-320x240.sh
+++ b/recipes-dsp/sensors/files/init-ov7670-320x240.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 
-IS_OLD_CONTROLLER=1
-if [ `cat /sys/class/graphics/fb0/id` == 00858552 ]; then IS_OLD_CONTROLLER=''; fi
+MCU_VERSION=`i2cget -y 2  0x48 0xee w`
+
+case ${MCU_VERSION} in
+     0x10* ) IS_OLD_CONTROLLER=1 ;;
+     0x28* ) IS_OLD_CONTROLLER='' ;;
+     *) echo ERROR in version detection; exit 1 ;;
+esac
+
+#IS_OLD_CONTROLLER=1
+#if [ `cat /sys/class/graphics/fb0/id` == 00858552 ]; then IS_OLD_CONTROLLER=''; fi
 
 VIDEO0=/dev/video0
 VIDEO1=/dev/video1
@@ -134,4 +142,4 @@ cam 0x54 0x40
 
 v4l2-ctl -d $VIDEO_PATH -s pal 1 > /dev/null
 echo "ov7670 successfully initialised" 
-echo 
+echo


### PR DESCRIPTION
This is needed as a workaround for a pixel clock glitch in
the "new" (spring 2018) TRIK video modules.
The modules seem to have the glitch during the start of line
code but only for normal clock polarity.

Set the clock polarity in sensors (write 0x10 to reg 0x15)
AND
in the receiver via the v4l2 S_CTRL ioctl (v4l2-ctl program).