### PR TITLE
fix a bug when >1 options are included in the DEFAULT_OPS variable

### DIFF
--- a/recipes-dsp/sensors/files/media-sensor
+++ b/recipes-dsp/sensors/files/media-sensor
@@ -126,12 +126,13 @@ do_cmd() {
   esac
 }
 
+
 do_reload() {
   check_dsp_busy
   cd $MEDIA_SENSOR_PATH
   clean_caches_plug
   init_camera
-  eval "DEFAULT_OPS=$DEFAULT_OPS"
+  eval "DEFAULT_OPS=\"$DEFAULT_OPS\""
   $MEDIA_SENSOR_PATH/$MEDIA_SENSOR_NAME $DEFAULT_OPS >$MEDIA_SENSOR_LOG 2>&1 & echo $! > $MEDIA_SENSOR_PID
   sleep 1    # wait for exposure stabilized
   fix_camera # fix exposure


### PR DESCRIPTION
if the variable before the eval has >1 space-separated options in it
then bash tries to execute the second option as a separate command
and fails.

Just copy-paste these lines to your command line to see this:
DEFAULT_OPS="a b"
eval "DEFAULT_OPS=$DEFAULT_OPS"