### PR TITLE
Fix do_configure failure

### DIFF
--- a/recipes-connectivity/ifplugd/ifplugd_0.28.bb
+++ b/recipes-connectivity/ifplugd/ifplugd_0.28.bb
@@ -17,7 +17,7 @@ SRC_URI +="file://kernel-types.patch \
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 
-inherit autotools update-rc.d 
+inherit autotools update-rc.d pkgconfig
 
 EXTRA_OECONF = "--disable-lynx"
 


### PR DESCRIPTION
do_configure() is fails 
log:
./ifplugd-0.28/configure: line 5366: syntax error near unexpected token `LIBDAEMON,'
| ../ifplugd-0.28/configure: line 5366: `PKG_CHECK_MODULES(LIBDAEMON,  libdaemon >= 0.5 )'
| WARNING: exit code 1 from a shell command.

this happens due to missing build dependency pkgconfig