### PR TITLE
Check password length && shellcheck passed

### DIFF
--- a/recipes-connectivity/trik-network/files/set_wifi_mode.sh
+++ b/recipes-connectivity/trik-network/files/set_wifi_mode.sh
@@ -70,7 +70,7 @@ case "$1" in
 	"ap")
 		source $trikrc
 
-		if [ "x$trik_wifi_ap_passphrase" = "x" ]; then
+		if [ "${#trik_wifi_ap_passphrase}" -ne "8" ]; then
 			generate_ap_passphrase
 		fi
 

--- a/recipes-connectivity/trik-network/files/set_wifi_mode.sh
+++ b/recipes-connectivity/trik-network/files/set_wifi_mode.sh
@@ -21,12 +21,9 @@ interface=wlan0
 generate_ap_passphrase() {
 	sed --in-place '/^trik_wifi_ap_passphrase=/d' $trikrc
 	trik_wifi_ap_passphrase=""
-	while [ "${#trik_wifi_ap_passphrase}" -ne "8" ]; do
-		for i in 1 2 3 4 5 6 7 8
-			do
-				digit=$(( $RANDOM % 10 ))
-				trik_wifi_ap_passphrase="${trik_wifi_ap_passphrase}${digit}"
-			done
+	for i in 1 2 3 4 5 6 7 8; do
+		digit=$(( $RANDOM % 10 ))
+		trik_wifi_ap_passphrase="${trik_wifi_ap_passphrase}${digit}"
 	done
 	echo "trik_wifi_ap_passphrase=$trik_wifi_ap_passphrase" >> $trikrc
 }

--- a/recipes-connectivity/trik-network/files/set_wifi_mode.sh
+++ b/recipes-connectivity/trik-network/files/set_wifi_mode.sh
@@ -21,13 +21,14 @@ interface=wlan0
 generate_ap_passphrase() {
 	sed --in-place '/^trik_wifi_ap_passphrase=/d' $trikrc
 	trik_wifi_ap_passphrase=""
-	for i in 1 2 3 4 5 6 7 8
-		do
-			digit=`expr $RANDOM % 10`
-			trik_wifi_ap_passphrase=$trik_wifi_ap_passphrase$digit
-		done
-	echo "trik_wifi_ap_passphrase=$trik_wifi_ap_passphrase" >>$trikrc
-	#we need to check length of $trik_wifi_ap_passphrase and regenerate if it is shorter than 8
+	while [ "${#trik_wifi_ap_passphrase}" -ne "8" ]; do
+		for i in 1 2 3 4 5 6 7 8
+			do
+				digit=$(( $RANDOM % 10 ))
+				trik_wifi_ap_passphrase="${trik_wifi_ap_passphrase}${digit}"
+			done
+	done
+	echo "trik_wifi_ap_passphrase=$trik_wifi_ap_passphrase" >> $trikrc
 }
 
 generate_hostapd_conf() {
@@ -46,19 +47,17 @@ wpa_pairwise=TKIP
 rsn_pairwise=CCMP" >$hostapd_conf
 }
 
-if [ ! $1 = "client" ] && [ ! $1 = "ap" ]
-	then
-		echo "Usage: set_wifi_mode.sh client|ap"
-		exit 1
+if [ ! "$1" = "client" ] && [ ! "$1" = "ap" ]; then
+	echo "Usage: set_wifi_mode.sh client|ap"
+	exit 1
 fi
 
 killall -q udhcpd
 /etc/init.d/hostapd stop
 ifdown $interface
 
-if [ ! -f $trikrc ]
-	then
-		touch $trikrc
+if [ ! -f $trikrc ]; then
+	touch $trikrc
 fi
 
 sed --in-place '/^trik_wifi_mode=/d' $trikrc
@@ -71,9 +70,8 @@ case "$1" in
 	"ap")
 		source $trikrc
 
-		if [ x$trik_wifi_ap_passphrase = x ]
-			then
-				generate_ap_passphrase
+		if [ "x$trik_wifi_ap_passphrase" = "x" ]; then
+			generate_ap_passphrase
 		fi
 
 		generate_hostapd_conf
@@ -84,5 +82,5 @@ case "$1" in
 		;;
 esac
 
-echo "trik_wifi_mode=$1" >>$trikrc
+echo "trik_wifi_mode=$1" >> $trikrc
 


### PR DESCRIPTION
Fix #118 

The main problem was in using expr. When digit is 0, expr returns non zero exit code. Here some discussions on topis can be found: https://unix.stackexchange.com/questions/63166/bash-e-exits-when-let-or-expr-evaluates-to-0