### PR TITLE
Add option to netcat about keep listening port when connection is ended

### DIFF
--- a/recipes-core/packagegroup/packagegroup-wifi.bb
+++ b/recipes-core/packagegroup/packagegroup-wifi.bb
@@ -13,7 +13,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS ?= ""
 
 
 RDEPENDS_${PN} = "\
-  netcat \
+  netcat-openbsd \
   wpa-supplicant \
   wireless-tools \
   hostapd \

--- a/recipes-trik/trik-runtime/files/gamepad-service
+++ b/recipes-trik/trik-runtime/files/gamepad-service
@@ -50,7 +50,7 @@ start() {
 
 do_start() {
   test -p $GAMEPAD_FIFO_PATH || { rm -f $GAMEPAD_FIFO_PATH ; mkfifo $GAMEPAD_FIFO_PATH ; }
-  $UTILITY_NAME -vlp $GAMEPAD_PORT | tee $GAMEPAD_FIFO_PATH &
+  $UTILITY_NAME -vlkp $GAMEPAD_PORT | tee $GAMEPAD_FIFO_PATH &
   wait
 }
 


### PR DESCRIPTION
There was a trouble with several connecting to gamepad during one boot session. Only first connection worked. As current solution -k option was added to nc to keep listening gamepad port. 