### PR TITLE
Added receipts for ti-wifi-utils

### DIFF
--- a/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -1,0 +1,25 @@
+SUMMARY = "The calibrator and other useful utilities for TI wireless solution based on wl12xx driver"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4725015cb0be7be389cf06deeae3683d"
+
+DEPENDS = "libnl"
+
+PV = "0.1+gitr${SRCPV}"
+
+SRCREV = "b03d9ce6362e6d22d6929f2736409af3b0fd3c88"
+SRC_URI = "git://github.com/TI-OpenLink/ti-utils.git;branch=r5-jb"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = 'CROSS_COMPILE=${TARGET_PREFIX} \
+                CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS}" \
+                CFLAGS="${CFLAGS} -I${STAGING_INCDIR}/libnl3 -DCONFIG_LIBNL20" NLVER=3 \
+                LDFLAGS="${LDFLAGS} ${TOOLCHAIN_OPTIONS}" \
+'
+
+#only install the calibrator utility, firmware is already within linux-firmware
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 calibrator ${D}${bindir}/
+}
+

--- a/recipes-core/images/trik-image-base.inc
+++ b/recipes-core/images/trik-image-base.inc
@@ -19,6 +19,7 @@ IMAGE_INSTALL = "packagegroup-base \
 		dsp-modules \
 		softap-udhcpd-config \
 		trik-network \
+		ti-wifi-utils \
 		fuse \
 		eglibc-utils \
 		packagegroup-triksensors \

--- a/recipes-core/images/trik-image-base.inc
+++ b/recipes-core/images/trik-image-base.inc
@@ -19,7 +19,6 @@ IMAGE_INSTALL = "packagegroup-base \
 		dsp-modules \
 		softap-udhcpd-config \
 		trik-network \
-		ti-wifi-utils \
 		fuse \
 		eglibc-utils \
 		packagegroup-triksensors \

--- a/recipes-core/packagegroup/packagegroup-wifi.bb
+++ b/recipes-core/packagegroup/packagegroup-wifi.bb
@@ -20,6 +20,7 @@ RDEPENDS_${PN} = "\
   trik-webpanel \
   linux-firmware-trik-wl1271 \
   tcpdump \
+  ti-wifi-utils \
   ${MACHINE_ESSENTIAL_EXTRA_RDEPENDS} \
  "
 


### PR DESCRIPTION
The base of recipe were found here: https://git.congatec.com/yocto/meta-openembedded/commit/f4958cfc976ece37784c82392b083ba481f69b8f 
I didn't find it in current morty version, therefore decided to add it. 