### PR TITLE
Change /images name for web-pannel

### DIFF
--- a/recipes-extended/lighttpd/lighttpd/lighttpd.conf
+++ b/recipes-extended/lighttpd/lighttpd/lighttpd.conf
@@ -351,14 +351,14 @@ $HTTP["url"] =~ "^/scripts/" {
      dir-listing.activate = "enable"
 }
 
-$HTTP["url"] =~ "^/images/" {
+$HTTP["url"] =~ "^/trikimages/" {
      dir-listing.activate = "enable"
 }
 
 alias.url = (
 	"/logs/" => "/var/trik/log/",
 	"/scripts/" => "/home/root/trik/scripts/",
-	"/images/" => "/home/root/trik/images/"
+	"/trikimages/" => "/home/root/trik/images/"
 )
 
 $HTTP["url"] =~ "^/web/" {


### PR DESCRIPTION
Web panel uses /images dir for html images, so doubling causes error