### PR TITLE
[WIP] New age revisited

### DIFF
--- a/recipes-core/images/trik-image-base.inc
+++ b/recipes-core/images/trik-image-base.inc
@@ -32,6 +32,8 @@ IMAGE_INSTALL = "packagegroup-base \
 		haveged \
 "
 
+BAD_RECOMMENDATIONS = "rng-tools"
+
 IMAGE_LINGUAS = "en-us ru-ru"
 
 LICENSE = "MIT"

--- a/recipes-trik/trik-runtime/files/gamepad-service
+++ b/recipes-trik/trik-runtime/files/gamepad-service
@@ -12,6 +12,8 @@
 
 set -euo pipefail
 
+. /etc/init.d/functions
+
 DEFAULT_SERVICE_NAME=gamepad-service
 
 CURRENT_SERVICE_NAME=current-gamepad-service


### PR DESCRIPTION
**List of cleanups for the new age**

1. Open ssh, which we use in the new age, pulls recommended dependency on rng-tools -- set of tools to speed up entropy calculation using the special "hw rng" chip in CPU. Discussion on appearance this in OE could be found here --  https://patches.openembedded.org/patch/161052/ . Since TRIK board doesn't have such a chip, rng-tools usage increases boot time up to 3 minutes in comparison to old one `haveged` rng (less than 1 min). `BAD_RECOMMENDS` flag is a standard way to decline such recommended package, in that case old `haveged` is used. **To discuss:** maybe this config should be placed in another config. 

Tiny fixes:
 * Fixed gamepad crash on undefined `status` command