### PR TITLE
Disabling RSA key generation and changing options for image compression.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 # meta-trik
 Meta layer for trik platform
 
-For more info https://github.com/IgnatSergeev/setup-scripts/blob/kirkstone/README.md
+For more info https://github.com/trikset/trik-distro
 
 `trik-image-core` dependencies:
-1. openembedded-core
+1. poky (openembedded-core)
 2. meta-openembedded
 3. meta-qt5
 4. meta-ti

--- a/classes/trik-sd-image.bbclass
+++ b/classes/trik-sd-image.bbclass
@@ -1,9 +1,9 @@
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 
-XZ_DICTIONARY_SIZE = "128"
-XZ_THREADS = "2"
-XZ_COMPRESSION_LEVEL ?= "--verbose --no-adjust --memlimit-compress=6GiB --arm --lzma2=mode=normal,dict=${XZ_DICTIONARY_SIZE}MiB,lc=1,lp=2,pb=2,mf=bt4,nice=192,depth=1024"
+XZ_DICTIONARY_SIZE = "64"
+XZ_THREADS = "5"
+XZ_COMPRESSION_LEVEL = "--verbose --no-adjust --memlimit-compress=6GiB --arm --lzma2=mode=normal,dict=${XZ_DICTIONARY_SIZE}MiB,lc=1,lp=2,pb=2,mf=bt4,nice=192,depth=1024"
 EXTRA_IMAGECMD:ext4 =+ " -E stride=2 -E stripe-width=16 -b 4096 -i 4096 "
 
 inherit image_types logging user-partion

--- a/recipes-connectivity/openssh/openssh/sshd_check_keys
+++ b/recipes-connectivity/openssh/openssh/sshd_check_keys
@@ -1,0 +1,75 @@
+#! /bin/sh
+
+generate_key() {
+    local FILE=$1
+    local TYPE=$2
+    local DIR="$(dirname "$FILE")"
+
+    mkdir -p "$DIR"
+    rm -f ${FILE}.tmp
+    ssh-keygen -q -f "${FILE}.tmp" -N '' -t $TYPE
+
+    # Atomically rename file public key
+    mv -f "${FILE}.tmp.pub" "${FILE}.pub"
+
+    # This sync does double duty: Ensuring that the data in the temporary
+    # private key file is on disk before the rename, and ensuring that the
+    # public key rename is completed before the private key rename, since we
+    # switch on the existence of the private key to trigger key generation.
+    # This does mean it is possible for the public key to exist, but be garbage
+    # but this is OK because in that case the private key won't exist and the
+    # keys will be regenerated.
+    #
+    # In the event that sync understands arguments that limit what it tries to
+    # fsync(), we provided them. If it does not, it will simply call sync()
+    # which is just as well
+    sync "${FILE}.pub" "$DIR" "${FILE}.tmp"
+
+    mv "${FILE}.tmp" "$FILE"
+
+    # sync to ensure the atomic rename is committed
+    sync "$DIR"
+}
+
+# /etc/default/ssh may set SYSCONFDIR and SSHD_OPTS
+if test -f /etc/default/ssh; then
+    . /etc/default/ssh
+fi
+
+[ -z "$SYSCONFDIR" ] && SYSCONFDIR=/etc/ssh
+mkdir -p $SYSCONFDIR
+
+# parse sshd options
+set -- ${SSHD_OPTS} --
+sshd_config=/etc/ssh/sshd_config
+while true ; do
+    case "$1" in
+    -f*) if [ "$1" = "-f" ] ; then
+            sshd_config="$2"
+            shift
+        else
+            sshd_config="${1#-f}"
+        fi
+        shift
+        ;;
+    --) shift; break;;
+    *) shift;;
+    esac
+done
+
+HOST_KEYS=$(sed -n 's/^[ \t]*HostKey[ \t]\+\(.*\)/\1/p' "${sshd_config}")
+[ -z "${HOST_KEYS}" ] && HOST_KEYS="$SYSCONFDIR/ssh_host_ecdsa_key $SYSCONFDIR/ssh_host_ed25519_key"
+
+for key in ${HOST_KEYS} ; do
+    [ -f $key ] && continue
+    case $key in
+    *_ecdsa_key)
+        echo "  generating ssh ECDSA host key..."
+        generate_key $key ecdsa
+        ;;
+    *_ed25519_key)
+        echo "  generating ssh ED25519 host key..."
+        generate_key $key ed25519
+        ;;
+    esac
+done

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,6 +1,9 @@
-#disable rng-tools, force haveged
-PACKAGECONFIG=""
-RRECOMMENDS:${PN}-sshd:append:class-target += " haveged"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-# should be in BSP somewhere in the machine.conf
-PACKAGE_EXCLUDE:append = " rng-tools"
+SRC_URI += "file://sshd_check_keys"
+
+do_install:append () {
+	install -D -m 0755 ${WORKDIR}/sshd_check_keys ${D}${libexecdir}/${BPN}/sshd_check_keys
+}
+
+FILES:${PN}-sshd += "${libexecdir}/${BPN}/sshd_check_keys"


### PR DESCRIPTION
Generating an RSA key takes a long time. We overwritten the bash script so as not to call the generation of the RSA key.

The options for image compression have been changed.