### PR TITLE
Refactor, disable asan, add qttools-native.

### DIFF
--- a/recipes-trik/trik-runtime/trik-runtime-qt5.inc
+++ b/recipes-trik/trik-runtime/trik-runtime-qt5.inc
@@ -6,7 +6,7 @@ RDEPENDS:${PN} = "locale-default espeak alsa-utils v4l-utils liberation-fonts mj
 #RRECOMMENDS:${PN} = "vlc"
 
 inherit qmake5 pkgconfig
-DEPENDS += "qtmultimedia qtscript"
+DEPENDS += "qtmultimedia qtscript qttools-native"
 #RREPLACES:${PN} += "trik-runtime"
 RCONFLICTS:${PN} += "trik-runtime-qt4"
 RPROVIDES:${PN} += "trik-runtime"
@@ -27,7 +27,6 @@ SRC_URI = "gitsm://github.com/trikset/trikRuntime.git;protocol=https;${GIT_REVIS
 S = "${WORKDIR}/git"
 
 QMAKE_PROFILES = "${S}/trikRuntime.pro"
-EXTRA_QMAKEVARS_PRE = "-r CONFIG+=release CONFIG+=ltcg CONFIG+=use_gold_linker CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=trik_nopython"
 
 do_compile(){
         export CROSS_COMPILE="${TARGET_PREFIX}"

--- a/recipes-trik/trik-runtime/trik-runtime-qt5_git.bb
+++ b/recipes-trik/trik-runtime/trik-runtime-qt5_git.bb
@@ -14,7 +14,10 @@ DEPENDS += "rsync-native python3"
 #OE_QMAKE_CXXFLAGS:append += " -fno-lto"
 
 #We need to switch precompiled headers off until this issue is fixed in trik-runtime sources
-EXTRA_QMAKEVARS_PRE += " -r CONFIG+=noPch CONFIG+=sanitize_address CONFIG+=sanitize_undefined"
+#We need to disable sanitize_address until the issue with the high memory consumption of asan is fixed
+EXTRA_QMAKEVARS_PRE += "-r CONFIG+=release CONFIG+=ltcg CONFIG+=use_gold_linker \
+			CONFIG+=trik_nopython CONFIG+=noPch CONFIG+=sanitize_undefined \
+			CONFIG+=sanitizer CONFIG-=sanitize_address"
 
 # For script gathering logs information
 RDEPENDS:${PN} += "bash xz"


### PR DESCRIPTION
Disabling asan because it consumed a lot of RAM. With endless redrawing of the accelerometer and gyroscope interfaces, it consumed all the memory and the system hung up.

Adding the qttools-native package for the lrealese qt linguist tool.