### PR TITLE
Remove pulseaudio

### DIFF
--- a/recipes-qt/qt5/qtmultimedia_%.bbappend
+++ b/recipes-qt/qt5/qtmultimedia_%.bbappend
@@ -1,4 +1,4 @@
 DEPENDS:remove = "qtdeclarative"
 DEPENDS += "qtbase"
 PACKAGECONFIG:remove = "gstreamer gstreamer010"
-# PACKAGECONFIG = "alsa"
+PACKAGECONFIG:remove = "pulseaudio"


### PR DESCRIPTION
With pulseaudio, the speaker does not work from the user space with Qt 5.15. 
Error: using null output device, none available.