### PR TITLE
Fix update MSP firmware

### DIFF
--- a/recipes-bsp/firmware/files/msp_reset.sh
+++ b/recipes-bsp/firmware/files/msp_reset.sh
@@ -1,6 +1,18 @@
 #!/bin/sh -e
 echo Resetting MSP ...
 # Put MSP to reset
+if [ ! -d /sys/class/gpio/gpio93 ]; then
+    echo "Export GPIO93"
+    echo 93 > /sys/class/gpio/export
+fi
+echo out > /sys/class/gpio/gpio93/direction
+
+if [ ! -d /sys/class/gpio/gpio80 ]; then
+    echo "Export GPIO80"
+    echo 80 > /sys/class/gpio/export
+fi
+echo out > /sys/class/gpio/gpio80/direction
+
 echo 0 > /sys/class/gpio/gpio93/value
 usleep 10000
 # Drive PUR pin high. Since PUR is wired to USB DP,

--- a/recipes-bsp/firmware/files/update_msp_fw.sh
+++ b/recipes-bsp/firmware/files/update_msp_fw.sh
@@ -48,4 +48,5 @@ tryUpdate
 # If MCU is fresh, there is no i2c responder and firmware variant is forced to 0x10*.
 # Now, i2c is available and we can tell proper MCU variant.
 # Thus, perform a second attempt to update firmware. It does not hurt anyway.
+sleep 3 # give some time for MSP to boot
 tryUpdate


### PR DESCRIPTION
If by default do not export the necessary GPIOs, we export them manually.