### PR TITLE
Disable UART (ttyS1) logs during Linux boot

### DIFF
--- a/recipes-bsp/u-boot-trik/u-boot-trik/trikboard/u-boot.cmd
+++ b/recipes-bsp/u-boot-trik/u-boot-trik/trikboard/u-boot.cmd
@@ -1,0 +1,3 @@
+setenv console ''
+saveenv
+

--- a/recipes-bsp/u-boot-trik/u-boot-trik_git.bb
+++ b/recipes-bsp/u-boot-trik/u-boot-trik_git.bb
@@ -1,15 +1,23 @@
 require u-boot-trik-common_${PV}.inc
 require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
 
-DEPENDS += "bc-native dtc-native"
+DEPENDS += "bc-native dtc-native u-boot-tools-native"
 
-SRC_URI += "file://update_uboot.sh"
+SRC_URI += "file://update_uboot.sh \
+	    file://u-boot.cmd \
+	    "
 
 P="${datadir}/${PN}"
-FILES:${PN} += "${datadir}/trik"
+FILES:${PN} += "${datadir}/trik /u-boot.run"
+
+do_compile:append() {
+  mkimage -T script -C none -n 'Script File' -d ${WORKDIR}/u-boot.cmd ${WORKDIR}/u-boot.scr
+}
 
 do_install:append () {
   install -p -D -m 0755 -t ${D}${datadir}/trik/init.d/ ${WORKDIR}/update_uboot.sh
+  install -p -D -m 0644 -t ${D}${P} ${WORKDIR}/u-boot.scr
+  ln -s ${P}/u-boot.scr ${D}/u-boot.run
 }
 
 do_deploy:append() {


### PR DESCRIPTION
Add a file that disables Linux boot logs on UART (`ttyS1`).

The console is set to an empty value using `console=''`. Unlike the previous version, there is no need to redirect the console to a dummy device like `ttyS2`, since this port does not exist on TRIK.

The `u-boot-tools-native` package is required to provide the `mkimage` utility.