### PR TITLE
Do not store U-Boot environment variables in persistent storage

### DIFF
--- a/recipes-bsp/u-boot-trik/u-boot-trik/trikboard/u-boot.cmd
+++ b/recipes-bsp/u-boot-trik/u-boot-trik/trikboard/u-boot.cmd
@@ -1,3 +1,2 @@
 setenv console ''
-saveenv
 


### PR DESCRIPTION
Do not write environment variables to persistent storage.

Saving variables via saveenv would permanently override settings such as console and removing the patch file would not re-enable the ttyS1 console, requiring manual recovery using fw_setenv.