### PR TITLE
Disabling name resolution for netcat (nc).

### DIFF
--- a/recipes-trik/trik-runtime/files/gamepad-service
+++ b/recipes-trik/trik-runtime/files/gamepad-service
@@ -52,7 +52,7 @@ start() {
 
 do_start() {
   test -p $GAMEPAD_FIFO_PATH || { rm -f $GAMEPAD_FIFO_PATH ; mkfifo $GAMEPAD_FIFO_PATH ; }
-  $UTILITY_NAME -vlkp $GAMEPAD_PORT | tee $GAMEPAD_FIFO_PATH &
+  $UTILITY_NAME -vlkn $GAMEPAD_PORT | tee $GAMEPAD_FIFO_PATH &
   wait
 }
 


### PR DESCRIPTION
The -n flag disables name resolution. This is necessary because some IP addresses cannot be resolved, causing the connection to fail.

The -p flag is not needed and is incorrectly specified in this case, as it controls the port from which connections and message sending will be initiated. On TRIK, we only listen.