### PR TITLE
Enable 12V motor power on older TRIK boards

### DIFF
--- a/recipes-bsp/firmware/files/update_msp_fw.sh
+++ b/recipes-bsp/firmware/files/update_msp_fw.sh
@@ -1,5 +1,16 @@
 #!/bin/sh -e
 
+# Enables 12V motor power on older TRIK boards.
+# GPIO signal opens the power switch for motor drivers.
+enableMotors12v() {
+    if [ ! -d /sys/class/gpio/gpio62 ]; then
+        echo "Export GPIO62"
+        echo 62 > /sys/class/gpio/export
+    fi
+    echo out > /sys/class/gpio/gpio62/direction
+    echo 1 > /sys/class/gpio/gpio62/value
+}
+
 hex2dec() {
     res=`printf "%d" "$1" 2>/dev/null`
     # do not return correct substring of incorrect string
@@ -44,6 +55,7 @@ tryUpdate() {
     return 0
 }
 
+enableMotors12v
 tryUpdate
 # If MCU is fresh, there is no i2c responder and firmware variant is forced to 0x10*.
 # Now, i2c is available and we can tell proper MCU variant.


### PR DESCRIPTION
Enable 12V motor power on older TRIK boards via GPIO.

The GPIO signal opens the power switch supplying 12V to the motor drivers.

On newer boards this pin is not connected, so it has no effect.