### PR TITLE
Disable asyncio import.

### DIFF
--- a/recipes-trik/trik-runtime/files/trikGui.sh
+++ b/recipes-trik/trik-runtime/files/trikGui.sh
@@ -9,6 +9,8 @@ which xset >/dev/null && ( xset s off ; xset s noblank ; xset -dpms ) || echo "M
 core_dump=$(/etc/trik/log_manager.sh --create)
 export ASAN_OPTIONS=detect_leaks=0:fast_unwind_on_malloc=1:detect_stack_use_after_return=0:disable_coredump=0:detect_odr_violation=0
 export LSAN_OPTIONS=suppressions=/home/root/trik/lsan.supp
+# Disabling import of the asyncio library for PythonEngine, as it takes ~7 seconds to import.
+export PYTHONQT_DISABLE_ASYNCIO=1
 cd /home/root/trik && ln -svft . configs/kernel-"$(uname -r | cut -f -2 -d .)"/*.xml \
   && nice -n -5 ./trikGui -c . -d ${core_dump} 1>/var/log/trikGui.log 2>&1 \
   || /etc/trik/log_manager.sh --collect ${core_dump}


### PR DESCRIPTION
The asyncio library is currently not needed, and importing it in PythonEngine takes about 7 seconds.