### PR TITLE
Fix wi-fi mode setup script.

### DIFF
--- a/recipes-connectivity/trik-network/files/set_wifi_mode.sh
+++ b/recipes-connectivity/trik-network/files/set_wifi_mode.sh
@@ -53,6 +53,16 @@ killall -q udhcpd
 /etc/init.d/hostapd stop
 ifdown $interface
 
+attempts=5
+while pgrep wpa_supplicant > /dev/null || pgrep hostapd > /dev/null; do
+    attempts=$((attempts - 1))
+    if [ $attempts -eq 0 ]; then
+        echo "Error switch wlan mode: processes still running" >&2
+        exit 1
+    fi
+    sleep 0.2
+done
+
 if [ ! -f $trikrc ]; then
 	touch $trikrc
 fi

--- a/recipes-core/init-ifupdown/init-ifupdown/trik-wlan0.cfg
+++ b/recipes-core/init-ifupdown/init-ifupdown/trik-wlan0.cfg
@@ -2,6 +2,6 @@
 iface wlan0 inet dhcp
 	wireless_mode managed
 	wireless_essid any
-	wpa-driver wext
+	wpa-driver nl80211
 	wpa-conf /etc/wpa_supplicant.conf
 


### PR DESCRIPTION
1. wpa-driver wext is not supported by some wi-fi adapter drivers as legacy, so switching to the modern wpa-driver nl80211

2. In the mode switching script we send a stop signal to processes, termination is not immediate, so we need to wait. This is especially noticeable with wpa-driver nl80211