### PR TITLE
Add kernel modules for USB Wi-Fi chipsets (adapters)

### DIFF
--- a/recipes-core/images/trik-image-base.inc
+++ b/recipes-core/images/trik-image-base.inc
@@ -29,6 +29,10 @@ IMAGE_INSTALL = "packagegroup-base \
 		trik-uart-ppp \
 		trik-mems \
 		python3-pip \
+		rtw88-mod \
+		rtl8188eu-mod \
+		rtl8188fu-mod \
+		rtl8822bu-mod \
 "
 
 BAD_RECOMMENDATIONS += "rng-tools"

--- a/recipes-kernel/modules/files/rtl8188eu/support-trik-platform-rtl8188eu.patch
+++ b/recipes-kernel/modules/files/rtl8188eu/support-trik-platform-rtl8188eu.patch
@@ -1,0 +1,46 @@
+From bc2495f2bdca945322f4ab9de40567d8e8ea6d79 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chehade=20Daniel=20=28=D0=A8=D0=B5=D1=85=D0=B0=D0=B4=D0=B5?=
+ =?UTF-8?q?=20=D0=94=D0=B0=D0=BD=D0=B8=D1=8D=D0=BB=D1=8C=29?=
+ <71555323+danielsheh02@users.noreply.github.com>
+Date: Fri, 17 Apr 2026 21:26:33 +0300
+Subject: [PATCH] support trik platform rtl8188eu
+
+---
+ Makefile | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 2aa7eef..d56276c 100755
+--- a/Makefile
++++ b/Makefile
+@@ -98,7 +98,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+ ###################### MP HW TX MODE FOR VHT #######################
+ CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+-CONFIG_PLATFORM_I386_PC = y
++CONFIG_PLATFORM_I386_PC = n
++CONFIG_PLATFORM_TRIK = y
+ CONFIG_PLATFORM_ARM_RPI = n
+ CONFIG_PLATFORM_ARM64_RPI = n
+ CONFIG_PLATFORM_ANDROID_X86 = n
+@@ -1035,6 +1036,17 @@ endif
+ 
+ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
+ 
++ifeq ($(CONFIG_PLATFORM_TRIK), y)
++EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
++EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++ARCH ?= arm
++CROSS_COMPILE ?= arm-oe-linux-gnueabi-
++KVER ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
++KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
++MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
++INSTALL_PREFIX :=
++endif
++
+ ifeq ($(CONFIG_PLATFORM_I386_PC), y)
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-- 
+2.43.0
+

--- a/recipes-kernel/modules/files/rtl8188fu/support-trik-platform-rtl8188fu.patch
+++ b/recipes-kernel/modules/files/rtl8188fu/support-trik-platform-rtl8188fu.patch
@@ -1,0 +1,46 @@
+From 5184c91e24e12f7c09d751fb4417bdb89f3c29b2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chehade=20Daniel=20=28=D0=A8=D0=B5=D1=85=D0=B0=D0=B4=D0=B5?=
+ =?UTF-8?q?=20=D0=94=D0=B0=D0=BD=D0=B8=D1=8D=D0=BB=D1=8C=29?=
+ <71555323+danielsheh02@users.noreply.github.com>
+Date: Fri, 17 Apr 2026 21:38:32 +0300
+Subject: [PATCH] support trik platform rtl8188fu
+
+---
+ Makefile | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 9d740d8..da3d3cf 100644
+--- a/Makefile
++++ b/Makefile
+@@ -64,7 +64,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+ ###################### MP HW TX MODE FOR VHT #######################
+ CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+-CONFIG_PLATFORM_I386_PC = y
++CONFIG_PLATFORM_I386_PC = n
++CONFIG_PLATFORM_TRIK = y
+ CONFIG_PLATFORM_ANDROID_X86 = n
+ CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+ CONFIG_PLATFORM_JB_X86 = n
+@@ -398,6 +399,17 @@ endif
+ 
+ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
+ 
++ifeq ($(CONFIG_PLATFORM_TRIK), y)
++EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
++EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++ARCH ?= arm
++CROSS_COMPILE ?= arm-oe-linux-gnueabi-
++KVER ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
++KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
++MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
++INSTALL_PREFIX :=
++endif
++
+ ifeq ($(CONFIG_PLATFORM_I386_PC), y)
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-- 
+2.43.0
+

--- a/recipes-kernel/modules/files/rtl8822bu/support-trik-platform-rtl8822bu.patch
+++ b/recipes-kernel/modules/files/rtl8822bu/support-trik-platform-rtl8822bu.patch
@@ -1,0 +1,62 @@
+From ab20ef15472e87144871e893d20b019b8fe3864c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chehade=20Daniel=20=28=D0=A8=D0=B5=D1=85=D0=B0=D0=B4=D0=B5?=
+ =?UTF-8?q?=20=D0=94=D0=B0=D0=BD=D0=B8=D1=8D=D0=BB=D1=8C=29?=
+ <71555323+danielsheh02@users.noreply.github.com>
+Date: Fri, 17 Apr 2026 22:35:53 +0300
+Subject: [PATCH] support trik platform rtl8822bu
+
+---
+ Makefile | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index f445960..baeae45 100644
+--- a/Makefile
++++ b/Makefile
+@@ -101,13 +101,13 @@ ccflags-y += -DCONFIG_RTW_ANDROID=$(CONFIG_RTW_ANDROID)
+ endif
+ 
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 3
+ 
+ # enable /proc/net/rtlxxxx/ debug interfaces
+-CONFIG_PROC_DEBUG = y
++CONFIG_PROC_DEBUG = n
+ 
+ ######################## Wake On Lan ##########################
+ CONFIG_WOWLAN = n
+@@ -137,7 +137,8 @@ CONFIG_LAYER2_ROAMING = y
+ #bit0: ROAM_ON_EXPIRED, #bit1: ROAM_ON_RESUME, #bit2: ROAM_ACTIVE
+ CONFIG_ROAMING_FLAG = 0x3
+ ###################### Platform Related #######################
+-CONFIG_PLATFORM_I386_PC = y
++CONFIG_PLATFORM_I386_PC = n
++CONFIG_PLATFORM_TRIK = y
+ CONFIG_PLATFORM_ANDROID_X86 = n
+ CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+ CONFIG_PLATFORM_JB_X86 = n
+@@ -1350,6 +1351,17 @@ INSTALL_PREFIX :=
+ STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging
+ endif
+ 
++ifeq ($(CONFIG_PLATFORM_TRIK), y)
++EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
++EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++ARCH ?= arm
++CROSS_COMPILE ?= arm-oe-linux-gnueabi-
++KVER ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
++KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
++MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
++INSTALL_PREFIX :=
++endif
++
+ ifeq ($(CONFIG_PLATFORM_NV_TK1), y)
+ ccflags-y += -DCONFIG_PLATFORM_NV_TK1
+ ccflags-y += -DCONFIG_LITTLE_ENDIAN
+-- 
+2.43.0
+

--- a/recipes-kernel/modules/files/rtw88/disable-rtl8822b-rtw88.patch
+++ b/recipes-kernel/modules/files/rtw88/disable-rtl8822b-rtw88.patch
@@ -1,0 +1,63 @@
+From 50736a781a63782f0875bf4f306481137851e635 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chehade=20Daniel=20=28=D0=A8=D0=B5=D1=85=D0=B0=D0=B4=D0=B5?=
+ =?UTF-8?q?=20=D0=94=D0=B0=D0=BD=D0=B8=D1=8D=D0=BB=D1=8C=29?=
+ <71555323+danielsheh02@users.noreply.github.com>
+Date: Fri, 17 Apr 2026 21:10:07 +0300
+Subject: [PATCH] disable 8822b in rtw88
+
+---
+ Makefile | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 2a26a06..8925fd6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,8 +5,8 @@ FWDIR := /lib/firmware/rtw88
+ JOBS ?= $(shell nproc --ignore=1)
+ MODLIST := rtw_8723cs rtw_8723de rtw_8723ds rtw_8723du \
+ 	   rtw_8812au rtw_8814ae rtw_8814au rtw_8821au rtw_8821ce rtw_8821cs rtw_8821cu \
+-	   rtw_8822be rtw_8822bs rtw_8822bu rtw_8822ce rtw_8822cs rtw_8822cu \
+-	   rtw_8703b rtw_8723d rtw_8821a rtw_8812a rtw_8814a rtw_8821c rtw_8822b rtw_8822c \
++	   rtw_8822ce rtw_8822cs rtw_8822cu \
++	   rtw_8703b rtw_8723d rtw_8821a rtw_8812a rtw_8814a rtw_8821c rtw_8822c \
+ 	   rtw_8723x rtw_88xxa rtw_pci rtw_sdio rtw_usb rtw_core
+ # Handle the move of the entire rtw88 tree
+ ifneq ("","$(wildcard /lib/modules/$(KVER)/kernel/drivers/net/wireless/realtek)")
+@@ -144,21 +144,21 @@ endif
+ obj-m		+= rtw_8821cu.o
+ rtw_8821cu-objs	:= rtw8821cu.o
+ 
+-obj-m		+= rtw_8822b.o
+-rtw_8822b-objs	:= rtw8822b.o rtw8822b_table.o
++# obj-m		+= rtw_8822b.o
++# rtw_8822b-objs	:= rtw8822b.o rtw8822b_table.o
+ 
+-ifeq ($(CONFIG_PCI), y)
+-obj-m		+= rtw_8822be.o
+-rtw_8822be-objs	:= rtw8822be.o
+-endif
++# ifeq ($(CONFIG_PCI), y)
++# obj-m		+= rtw_8822be.o
++# rtw_8822be-objs	:= rtw8822be.o
++# endif
+ 
+-ifneq ($(CONFIG_MMC), )
+-obj-m		+= rtw_8822bs.o
+-rtw_8822bs-objs	:= rtw8822bs.o
+-endif
++# ifneq ($(CONFIG_MMC), )
++# obj-m		+= rtw_8822bs.o
++# rtw_8822bs-objs	:= rtw8822bs.o
++# endif
+ 
+-obj-m		+= rtw_8822bu.o
+-rtw_8822bu-objs	:= rtw8822bu.o
++# obj-m		+= rtw_8822bu.o
++# rtw_8822bu-objs	:= rtw8822bu.o
+ 
+ obj-m		+= rtw_8822c.o
+ rtw_8822c-objs	:= rtw8822c.o rtw8822c_table.o
+-- 
+2.43.0
+

--- a/recipes-kernel/modules/files/rtw88/support-linux-4.14-rtw88.patch
+++ b/recipes-kernel/modules/files/rtw88/support-linux-4.14-rtw88.patch
@@ -1,0 +1,283 @@
+From 5a36669ba1165d683188decaaae5e4aee1407cf4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chehade=20Daniel=20=28=D0=A8=D0=B5=D1=85=D0=B0=D0=B4=D0=B5?=
+ =?UTF-8?q?=20=D0=94=D0=B0=D0=BD=D0=B8=D1=8D=D0=BB=D1=8C=29?=
+ <71555323+danielsheh02@users.noreply.github.com>
+Date: Fri, 10 Apr 2026 16:43:14 +0300
+Subject: [PATCH] Support linux 4.14
+
+---
+ fw.c       |  4 ++++
+ mac80211.c |  6 ++++++
+ main.c     |  6 ++++++
+ main.h     | 28 ++++++++++++++++++++++++++++
+ rtw8812a.c |  2 ++
+ rtw8814a.c |  2 ++
+ rtw8814a.h |  2 ++
+ rtw8821a.c |  2 ++
+ rtw8821c.c |  2 ++
+ rtw8822b.c |  2 ++
+ rtw8822c.c |  2 ++
+ rtw88xxa.h |  2 ++
+ rx.c       |  2 ++
+ sar.c      |  2 ++
+ tx.c       |  2 ++
+ 15 files changed, 66 insertions(+)
+
+diff --git a/fw.c b/fw.c
+index 0efaea0..79cb1b0 100644
+--- a/fw.c
++++ b/fw.c
+@@ -2239,7 +2239,11 @@ static void rtw_fw_set_scan_offload(struct rtw_dev *rtwdev,
+ 	struct rtw_fifo_conf *fifo = &rtwdev->fifo;
+ 	/* reserve one dummy page at the beginning for tx descriptor */
+ 	u8 pkt_loc = fifo->rsvd_h2c_info_addr - fifo->rsvd_boundary + 1;
++#ifdef NL80211_SCAN_FLAG_RANDOM_SN
+ 	bool random_seq = req->flags & NL80211_SCAN_FLAG_RANDOM_SN;
++#else
++	bool random_seq = false;
++#endif
+ 	u8 h2c_pkt[H2C_PKT_SIZE] = {0};
+ 
+ 	rtw_h2c_pkt_set_header(h2c_pkt, H2C_PKT_SCAN_OFFLOAD);
+diff --git a/mac80211.c b/mac80211.c
+index 9bf2b4e..aa0876f 100644
+--- a/mac80211.c
++++ b/mac80211.c
+@@ -1065,8 +1065,14 @@ const struct ieee80211_ops rtw_ops = {
+ 	.set_antenna		= rtw_ops_set_antenna,
+ 	.get_antenna		= rtw_ops_get_antenna,
+ 	.reconfig_complete	= rtw_reconfig_complete,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
++	/* On kernels < 5.0, hw_scan returning 1 is treated as a hard error
++	 * rather than a "fall back to software scan" signal, so we disable
++	 * hw_scan and let mac80211 use its built-in software scan instead.
++	 */
+ 	.hw_scan		= rtw_ops_hw_scan,
+ 	.cancel_hw_scan		= rtw_ops_cancel_hw_scan,
++#endif
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ 	.sta_rc_update		= rtw_ops_sta_rc_update,
+ #else
+diff --git a/main.c b/main.c
+index f9a6fb7..0d568d5 100644
+--- a/main.c
++++ b/main.c
+@@ -2392,7 +2392,9 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ 		ieee80211_hw_set(hw, SUPPORTS_AMSDU_IN_AMPDU);
+ 	ieee80211_hw_set(hw, HAS_RATE_CONTROL);
+ 	ieee80211_hw_set(hw, TX_AMSDU);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+ 	ieee80211_hw_set(hw, SINGLE_SCAN_ON_ALL_BANDS);
++#endif
+ 
+ 	hw->wiphy->interface_modes = BIT(NL80211_IFTYPE_STATION) |
+ 				     BIT(NL80211_IFTYPE_AP) |
+@@ -2412,8 +2414,12 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ 	hw->wiphy->iface_combinations = rtw_iface_combs;
+ 	hw->wiphy->n_iface_combinations = ARRAY_SIZE(rtw_iface_combs);
+ 
++#ifdef NL80211_EXT_FEATURE_CAN_REPLACE_PTK0
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_CAN_REPLACE_PTK0);
++#endif
++#ifdef NL80211_EXT_FEATURE_SCAN_RANDOM_SN
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SCAN_RANDOM_SN);
++#endif
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SET_SCAN_DWELL);
+ 
+ #ifdef CONFIG_PM
+diff --git a/main.h b/main.h
+index a05fdd6..7fa8537 100644
+--- a/main.h
++++ b/main.h
+@@ -36,6 +36,34 @@
+ #define RHEL_RELEASE_VERSION(a, b) a<<8 & b
+ #endif
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
++/* __nonstring was introduced in GCC 8 / kernel 4.16 */
++#ifndef __nonstring
++#define __nonstring
++#endif
++/* ieee80211_is_any_nullfunc() was added in kernel 4.16 */
++static inline bool ieee80211_is_any_nullfunc(__le16 fc)
++{
++	return (ieee80211_is_nullfunc(fc) || ieee80211_is_qos_nullfunc(fc));
++}
++#endif
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
++/* skb_copy_header() was added in kernel 5.18 */
++static inline void skb_copy_header(struct sk_buff *n, const struct sk_buff *o)
++{
++	n->dev = o->dev;
++	memcpy(n->cb, o->cb, sizeof(o->cb));
++}
++#endif
++
++/* module_sdio_driver() may be absent in some vendor 4.x kernels */
++#ifndef module_sdio_driver
++#define module_sdio_driver(__sdio_driver) \
++	module_driver(__sdio_driver, sdio_register_driver, \
++		      sdio_unregister_driver)
++#endif
++
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ /* Taken from kernel 6.18.1: include/linux/device/devres.h
+  * Removed size_dup(...) to support kernels older than 5.15. */
+diff --git a/rtw8812a.c b/rtw8812a.c
+index 6e12246..58de9ed 100644
+--- a/rtw8812a.c
++++ b/rtw8812a.c
+@@ -1035,7 +1035,9 @@ static const struct coex_rf_para rf_para_rx_8812a[] = {
+ 	{0, 28, true, 5}
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rf_para_tx_8812a) == ARRAY_SIZE(rf_para_rx_8812a));
++#endif
+ 
+ const struct rtw_chip_info rtw8812a_hw_spec = {
+ 	.ops = &rtw8812a_ops,
+diff --git a/rtw8814a.c b/rtw8814a.c
+index 2d065e7..3d55e16 100644
+--- a/rtw8814a.c
++++ b/rtw8814a.c
+@@ -2175,7 +2175,9 @@ static const struct coex_rf_para rf_para_rx_8814a[] = {
+ 	{1, 13, true, 1}
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rf_para_tx_8814a) == ARRAY_SIZE(rf_para_rx_8814a));
++#endif
+ 
+ const struct rtw_chip_info rtw8814a_hw_spec = {
+ 	.ops = &rtw8814a_ops,
+diff --git a/rtw8814a.h b/rtw8814a.h
+index c57c7c8..12fd655 100644
+--- a/rtw8814a.h
++++ b/rtw8814a.h
+@@ -55,7 +55,9 @@ struct rtw8814a_efuse {
+ 	u8 res5[0x122];			/* 0xde */
+ } __packed;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(sizeof(struct rtw8814a_efuse) == 512);
++#endif
+ 
+ extern const struct rtw_chip_info rtw8814a_hw_spec;
+ 
+diff --git a/rtw8821a.c b/rtw8821a.c
+index ab58934..7442c52 100644
+--- a/rtw8821a.c
++++ b/rtw8821a.c
+@@ -1108,7 +1108,9 @@ static const struct coex_rf_para rf_para_rx_8821a[] = {
+ 	{0, 28, true, 5}
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rf_para_tx_8821a) == ARRAY_SIZE(rf_para_rx_8821a));
++#endif
+ 
+ static const struct coex_5g_afh_map afh_5g_8821a[] = { {0, 0, 0} };
+ 
+diff --git a/rtw8821c.c b/rtw8821c.c
+index 3859390..d3cb1c9 100644
+--- a/rtw8821c.c
++++ b/rtw8821c.c
+@@ -1838,7 +1838,9 @@ static const struct coex_rf_para rf_para_rx_8821c[] = {
+ 	{0, 28, true, 5}
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rf_para_tx_8821c) == ARRAY_SIZE(rf_para_rx_8821c));
++#endif
+ 
+ static const u8 rtw8821c_pwrtrk_5gb_n[][RTW_PWR_TRK_TBL_SZ] = {
+ 	{0, 1, 1, 2, 3, 3, 3, 4, 4, 5, 5, 6, 6, 6, 7, 8, 8, 8, 9, 9, 9, 10, 10,
+diff --git a/rtw8822b.c b/rtw8822b.c
+index 128b901..0bda158 100644
+--- a/rtw8822b.c
++++ b/rtw8822b.c
+@@ -2351,7 +2351,9 @@ static const struct coex_5g_afh_map afh_5g_8822b[] = {
+ 	{138, 37, 34},
+ 	{155, 68, 20}
+ };
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rf_para_tx_8822b) == ARRAY_SIZE(rf_para_rx_8822b));
++#endif
+ 
+ static const u8
+ rtw8822b_pwrtrk_5gb_n[RTW_PWR_TRK_5G_NUM][RTW_PWR_TRK_TBL_SZ] = {
+diff --git a/rtw8822c.c b/rtw8822c.c
+index aa880da..b2b802a 100644
+--- a/rtw8822c.c
++++ b/rtw8822c.c
+@@ -5151,7 +5151,9 @@ static const struct coex_rf_para rf_para_rx_8822c[] = {
+ 	{0, 28, true, 5}   /* for gamg hid */
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rf_para_tx_8822c) == ARRAY_SIZE(rf_para_rx_8822c));
++#endif
+ 
+ static const u8
+ rtw8822c_pwrtrk_5gb_n[RTW_PWR_TRK_5G_NUM][RTW_PWR_TRK_TBL_SZ] = {
+diff --git a/rtw88xxa.h b/rtw88xxa.h
+index aedbdf4..9f5c577 100644
+--- a/rtw88xxa.h
++++ b/rtw88xxa.h
+@@ -71,7 +71,9 @@ struct rtw88xxa_efuse {
+ 	};
+ } __packed;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(sizeof(struct rtw88xxa_efuse) == 512);
++#endif
+ 
+ #define WLAN_BCN_DMA_TIME			0x02
+ #define WLAN_TBTT_PROHIBIT			0x04
+diff --git a/rx.c b/rx.c
+index 1e6628a..428f0b7 100644
+--- a/rx.c
++++ b/rx.c
+@@ -284,7 +284,9 @@ static void rtw_rx_fill_rx_status(struct rtw_dev *rtwdev,
+ 	 * simply drops the packet.
+ 	 */
+ 	if (rtwdev->chip->id == RTW_CHIP_TYPE_8703B && pkt_stat->pkt_len == 0) {
++#ifdef RX_FLAG_NO_PSDU
+ 		rx_status->flag |= RX_FLAG_NO_PSDU;
++#endif
+ 		rtw_dbg(rtwdev, RTW_DBG_RX, "zero length packet");
+ 	}
+ }
+diff --git a/sar.c b/sar.c
+index 5b35cee..00d8781 100644
+--- a/sar.c
++++ b/sar.c
+@@ -64,7 +64,9 @@ static const struct cfg80211_sar_freq_ranges rtw_common_sar_freq_ranges[] = {
+ 	[RTW_SAR_BAND_4] = { .start_freq = 5745, .end_freq = 5825, },
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(rtw_common_sar_freq_ranges) == RTW_SAR_BAND_NR);
++#endif
+ 
+ const struct cfg80211_sar_capa rtw_sar_capa = {
+ 	.type = NL80211_SAR_TYPE_POWER,
+diff --git a/tx.c b/tx.c
+index e648816..1767bb0 100644
+--- a/tx.c
++++ b/tx.c
+@@ -757,7 +757,9 @@ static const enum rtw_tx_queue_type ac_to_hwq[] = {
+ 	[IEEE80211_AC_BK] = RTW_TX_QUEUE_BK,
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+ static_assert(ARRAY_SIZE(ac_to_hwq) == IEEE80211_NUM_ACS);
++#endif
+ 
+ enum rtw_tx_queue_type rtw_tx_ac_to_hwq(enum ieee80211_ac_numbers ac)
+ {
+-- 
+2.43.0
+

--- a/recipes-kernel/modules/rtl8188eu-mod_1.0.bb
+++ b/recipes-kernel/modules/rtl8188eu-mod_1.0.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Realtek rtl8188eu, rtl8188eu, rtl8188etv USB WiFi driver"
+DESCRIPTION = "Out-of-tree kernel module for rtl8188eu, rtl8188eu, rtl8188etv"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit module
+
+SRC_URI = "git://github.com/aircrack-ng/rtl8188eus.git;protocol=https;branch=v5.3.9 \
+	   file://rtl8188eu/support-trik-platform-rtl8188eu.patch \
+	   "
+SRCREV = "af3bf004458f76b7aec33e9ba552cd382ed1f5c3"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+    install -m 0644 ${S}/*.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+}

--- a/recipes-kernel/modules/rtl8188fu-mod_1.0.bb
+++ b/recipes-kernel/modules/rtl8188fu-mod_1.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Realtek rtl8188fu USB WiFi driver"
+DESCRIPTION = "Out-of-tree kernel module for rtl8188fu"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit module
+
+SRC_URI = "git://github.com/kelebek333/rtl8188fu.git;protocol=https;branch=master \
+	   file://rtl8188fu/support-trik-platform-rtl8188fu.patch \
+	   "
+SRCREV = "7ce43037212aab03a5cfe441992eee04de7f858d"
+
+S = "${WORKDIR}/git"
+
+FILES:${PN} += "/lib/firmware/rtlwifi/*"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+    install -m 0644 ${S}/*.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+    
+    install -d ${D}${nonarch_base_libdir}/firmware/rtlwifi
+    install -m 0644 ${S}/firmware/*.bin ${D}${nonarch_base_libdir}/firmware/rtlwifi/
+}

--- a/recipes-kernel/modules/rtl8822bu-mod_1.0.bb
+++ b/recipes-kernel/modules/rtl8822bu-mod_1.0.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Realtek rtl8188fu USB WiFi driver"
+DESCRIPTION = "Out-of-tree kernel module for rtl8188fu"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit module
+
+SRC_URI = "git://github.com/RinCat/RTL88x2BU-Linux-Driver.git;protocol=https;branch=master \
+	   file://rtl8822bu/support-trik-platform-rtl8822bu.patch \
+	   "
+SRCREV = "825556e195ecde9ce8f5f4cbad9953f398c8598e"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+    install -m 0644 ${S}/*.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+}

--- a/recipes-kernel/modules/rtw88-mod_1.0.bb
+++ b/recipes-kernel/modules/rtw88-mod_1.0.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Realtek rtw88xx USB WiFi driver"
+DESCRIPTION = "Out-of-tree kernel module for rtw88xx"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit module
+
+# rtw88 are mainline Linux modules for all wi-fi 5 chips
+# disable rtl8822b chip as it is non-functional 
+# may work on Linux 5+, worth trying after upgrade
+SRC_URI = "git://github.com/lwfinger/rtw88.git;protocol=https;branch=master \
+           file://rtw88/support-linux-4.14-rtw88.patch \
+           file://rtw88/disable-rtl8822b-rtw88.patch \
+           "
+SRCREV = "d2258b4de21aeabf7ef85ec0cada1f3cff9bcbe0"
+S = "${WORKDIR}/git"
+
+# Only USB support is needed
+# These CONFIGs may be set in the defconfig, override them for the driver
+EXTRA_OEMAKE += "CONFIG_PCI=n"
+
+# here just empty
+EXTRA_OEMAKE += "CONFIG_MMC="
+
+FILES:${PN} += "/lib/firmware/rtw88/*"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+    install -m 0644 ${S}/*.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/extra/
+        
+    install -d ${D}${nonarch_base_libdir}/firmware/rtw88
+    install -m 0644 ${S}/firmware/*.bin ${D}${nonarch_base_libdir}/firmware/rtw88/
+}


### PR DESCRIPTION
Kernel modules for Realtek chipsets:

1. Two modules for Wi-Fi 4 (2.4 GHz): rtl8188eu and rtl8188fu

2. A large set of mainline rtw88 modules from the kernel for Wi-Fi 5 (2.4 GHz and 5 GHz)

3. Since rtl8822bu does not work with the rtw88 set, it was added separately