### PR TITLE
Add ROS2 Humble support to SDK/image build

### DIFF
--- a/recipes-core/images/trik-image-ros2.bb
+++ b/recipes-core/images/trik-image-ros2.bb
@@ -1,0 +1,7 @@
+require trik-image-base.inc
+
+SUMMARY = "TRIK image with ROS2 Humble"
+
+IMAGE_INSTALL += "\
+    packagegroup-ros2-base \
+"

--- a/recipes-devtools/meta/meta-toolchain-trik.bb
+++ b/recipes-devtools/meta/meta-toolchain-trik.bb
@@ -8,6 +8,7 @@ require recipes-qt/meta/meta-toolchain-qt5.bb
 
 TOOLCHAIN_HOST_TASK += "nativesdk-packagegroup-trik-toolchain-host"
 TOOLCHAIN_TARGET_TASK += "packagegroup-trik-toolchain-target"
+TOOLCHAIN_TARGET_TASK += "packagegroup-trik-toolchain-ros2-target"
 
 #TOOLCHAIN_TARGET_TASK += "packagegroup-ros-comm"
 TOOLCHAIN_OUTPUTNAME = "${SDK_NAME}-toolchain-trik-${DISTRO_VERSION}"

--- a/recipes-devtools/packagegroups/packagegroup-trik-toolchain-ros2-target.bb
+++ b/recipes-devtools/packagegroups/packagegroup-trik-toolchain-ros2-target.bb
@@ -1,0 +1,35 @@
+SUMMARY = "ROS2 Humble dev headers and cmake configs for TRIK SDK"
+LICENSE = "MIT"
+
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
+inherit packagegroup
+
+# Headers and cmake configs for writing ROS2 C++ nodes against TRIK target
+RDEPENDS:${PN} += " \
+    rclcpp-dev \
+    rcl-dev \
+    rcl-interfaces-dev \
+    rcl-lifecycle-dev \
+    rclcpp-lifecycle-dev \
+    rclcpp-components-dev \
+    rclcpp-action-dev \
+    rosidl-runtime-c-dev \
+    rosidl-runtime-cpp-dev \
+    rosidl-typesupport-interface-dev \
+    rosidl-typesupport-introspection-c-dev \
+    rosidl-typesupport-introspection-cpp-dev \
+    cyclonedds-dev \
+    rmw-dev \
+    rmw-cyclonedds-cpp-dev \
+    std-msgs-dev \
+    std-srvs-dev \
+    builtin-interfaces-dev \
+    rcl-interfaces-dev \
+    action-msgs-dev \
+    lifecycle-msgs-dev \
+    composition-interfaces-dev \
+    common-interfaces-dev \
+    ament-cmake-dev \
+    ament-index-cpp-dev \
+"

--- a/recipes-ros/iceoryx/iceoryx-hoofs/disable-atomic-assert.patch
+++ b/recipes-ros/iceoryx/iceoryx-hoofs/disable-atomic-assert.patch
@@ -1,0 +1,27 @@
+From 1f61dc0711d375a4b96ca93d8f68c4fd0475a4e7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chehade=20Daniel=20=28=D0=A8=D0=B5=D1=85=D0=B0=D0=B4=D0=B5?=
+ =?UTF-8?q?=20=D0=94=D0=B0=D0=BD=D0=B8=D1=8D=D0=BB=D1=8C=29?=
+ <71555323+danielsheh02@users.noreply.github.com>
+Date: Sun, 21 Jun 2026 20:34:28 +0300
+Subject: [PATCH] disable assert
+
+---
+ include/iceoryx_hoofs/internal/concurrent/sofi.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/iceoryx_hoofs/internal/concurrent/sofi.hpp b/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+index cc4bd2d7..a5fceecc 100644
+--- a/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
++++ b/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+@@ -50,7 +50,7 @@ class SoFi
+     /// ATOMIC_INT_LOCK_FREE = 2 - is always lockfree
+     /// ATOMIC_INT_LOCK_FREE = 1 - is sometimes lockfree
+     /// ATOMIC_INT_LOCK_FREE = 0 - is never lockfree
+-    static_assert(2 <= ATOMIC_INT_LOCK_FREE, "SoFi is not able to run lock free on this data type");
++    /// static_assert(2 <= ATOMIC_INT_LOCK_FREE, "SoFi is not able to run lock free on this data type");
+ 
+     /// @brief Internal size needs to be bigger than the size desirred by the user
+     /// This is because of buffer empty detection and overflow handling
+-- 
+2.43.0
+

--- a/recipes-ros/iceoryx/iceoryx-hoofs_%.bbappend
+++ b/recipes-ros/iceoryx/iceoryx-hoofs_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://disable-atomic-assert.patch"

--- a/recipes-ros/packagegroups/packagegroup-ros2-base.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros2-base.bb
@@ -1,0 +1,65 @@
+SUMMARY = "ROS2 Humble minimal package group for TRIK board"
+DESCRIPTION = "\
+    Minimal ROS2 Humble stack for ARM926EJS (OMAP L138). \
+    Uses Cyclone DDS as the lightest available rmw middleware. \
+    GUI tools, simulation and heavy-weight packages are excluded. \
+"
+LICENSE = "MIT"
+
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
+inherit packagegroup
+
+# Core ROS2 client libraries
+ROS2_CORE = "\
+    ros-core \
+    rclcpp \
+    rclpy \
+"
+
+# Cyclone DDS - lightest DDS implementation (~30 MB vs ~80 MB for Fast-DDS)
+ROS2_MIDDLEWARE = "\
+    cyclonedds \
+    rmw-cyclonedds-cpp \
+    rosidl-typesupport-fastrtps-c \
+    rosidl-typesupport-fastrtps-cpp \
+"
+
+# Standard message types needed by virtually every ROS2 node
+ROS2_MSGS = "\
+    std-msgs \
+    std-srvs \
+    builtin-interfaces \
+    rcl-interfaces \
+    common-interfaces \
+    action-msgs \
+    lifecycle-msgs \
+    composition-interfaces \
+"
+
+# Command-line tools for diagnostics
+ROS2_TOOLS = "\
+    ros2cli \
+    ros2topic \
+    ros2node \
+    ros2service \
+    ros2param \
+    ros2run \
+    ros2launch \
+"
+
+# Launch infrastructure
+ROS2_LAUNCH = "\
+    launch \
+    launch-ros \
+    launch-xml \
+    launch-yaml \
+"
+
+RDEPENDS:${PN} = "\
+    ${ROS2_CORE} \
+    ${ROS2_MIDDLEWARE} \
+    ${ROS2_MSGS} \
+    ${ROS2_TOOLS} \
+    ${ROS2_LAUNCH} \
+"


### PR DESCRIPTION
Add packagegroup-ros2-base (rclcpp/rclpy core, CycloneDDS middleware, common msgs, CLI tools, launch infra) and trik-image-ros2, plus a ros2-target packagegroup added to the SDK toolchain with headers and cmake configs for building ROS2 C++ nodes against TRIK.

Disable iceoryx-hoofs' static_assert requiring ATOMIC_INT_LOCK_FREE == 2: our target falls back to mutex-based CAS, which is fine since TRIK is single-core. TODO: investigate rebuilding gcc with HAVE_KERNEL64 to get lock-free 64-bit atomics via kernel helpers, or whether the assert can be safely relaxed instead.